### PR TITLE
Update info.yaml

### DIFF
--- a/info.yaml
+++ b/info.yaml
@@ -10,7 +10,7 @@ project:
 
 # test within caravel
 caravel_test:
-  recipe: "project"
+  recipe: "all"
   directory: "caravel_test"
   id: 5
   module_name: "wrapped_quad_pwm_fet_drivers"


### PR DESCRIPTION
change rule name for caravel test to all
project isn't a rule, so can't be used as default recipe